### PR TITLE
Make CustomGeneratorRun optional parameter

### DIFF
--- a/src/lib/Mocker.ts
+++ b/src/lib/Mocker.ts
@@ -23,7 +23,7 @@ export class Mocker {
         return this
     }
 
-    addGenerator(name: string, library: any, run: CustomGeneratorRun): Mocker {
+    addGenerator(name: string, library: any, run?: CustomGeneratorRun): Mocker {
         this.generators[name] = { library, run }
         return this
     }


### PR DESCRIPTION
The run parameter is not required on addGenerator according to the docs. Make it an optional param